### PR TITLE
Fixed rss feed title & description

### DIFF
--- a/rss.xml
+++ b/rss.xml
@@ -3,8 +3,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>{{ site.name | xml_escape }}</title>
-    <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
+    <title>{{ site.noita.name | xml_escape }}</title>
+    <description>{% if site.noita.description %}{{ site.noita.description | xml_escape }}{% endif %}</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
     {% for post in site.posts limit:10 %}


### PR DESCRIPTION
Currently the RSS feed has an empty title & description which makes it show up as "Untitled" my my reader.

This change updates the rss feed to use the same variables as the atom feed for the name and description.